### PR TITLE
Add Query Params for `steps` and make it `30m` by default

### DIFF
--- a/src/controllers/widget.controller.js
+++ b/src/controllers/widget.controller.js
@@ -132,11 +132,24 @@ const Poll = async (req, res) => {
       return;
     }
 
+
+    //TODO remove this when the type of Range is back to string.
+    //This also includes a default for steps, this can still be overwritten with query params
+    {
+      widget.Range = "24h";
+      widget.Steps = "30m";
+    }
+
     //Handle query overrides
     {
       if (typeof req.query.range == "string" && req.query.range.length > 0) {
         //Custom range is defined
-        widget.DefaultRange = req.query.range;
+        widget.Range = req.query.range;
+      }
+
+      if(typeof req.query.steps == "string" && req.query.steps.length > 0){
+        //Custom steps is defined
+        widget.Steps = req.query.steps;
       }
     }
 

--- a/src/services/influxdb.service.js
+++ b/src/services/influxdb.service.js
@@ -18,11 +18,18 @@ function buildFluxQuery(widget) {
   let queryParams = {
     range: null,
     filter: null,
+    steps: "",
   };
 
   //Filter Range
   {
     queryParams.range = `|> range(start: -${widget.Range})`;
+  }
+
+  //Steps
+  if(widget.Steps != undefined)
+  {
+    queryParams.steps = `|> aggregateWindow(every: ${widget.Steps}, fn: mean)`
   }
 
   //Construct Filter
@@ -37,7 +44,8 @@ function buildFluxQuery(widget) {
 
   const fluxQuery = `from(bucket: "${bucket}")
   ${queryParams.range}
-  ${queryParams.filter}`;
+  ${queryParams.filter}
+  ${queryParams.steps}`;
 
   // fluxquery teruggeven
   return fluxQuery;


### PR DESCRIPTION
Standaard is de range nu 24h, met steps van 30m. Doormiddel van Query params kun je deze nog overwriten.

Voorbeeld: `{{BackendAPI}}/api/widgets/poll/:id?range=10m&steps=1m`